### PR TITLE
ci: bootstrap the .github folder

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Default owners for everything
+* @toon-format/rust-maintainers
+
+# Project governance and documentation
+CODE_OF_CONDUCT.md @johannschopplich
+CONTRIBUTING.md @johannschopplich
+LICENSE @johannschopplich
+README.md @johannschopplich

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,67 @@
+name: Bug Report
+description: Report a bug or unexpected behavior
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug!
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear description of what the bug is
+      placeholder: When I try to encode..., I expect..., but instead...
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction Steps
+      description: Steps to reproduce the behavior
+      placeholder: |
+        1. Import toon_format
+        2. Call encode() with...
+        3. See error...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What you expected to happen
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened (including error messages)
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: |
+        Please provide:
+        - Rust toolchain version
+        - toon-format version
+        - Operating system
+      placeholder: |
+        - rustc 1.91.0
+        - toon-format 0.1.0
+        - macOS 14.0
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Any other context about the problem (optional)

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,48 @@
+name: Feature Request
+description: Suggest a new feature or enhancement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a feature!
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: What problem does this feature solve?
+      placeholder: As a user, I want to... because...
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: How would you like this to work?
+      placeholder: |
+        Add a new method/function that...
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: What alternative solutions have you considered?
+
+  - type: textarea
+    id: spec
+    attributes:
+      label: SPEC Compliance
+      description: |
+        Does this relate to the TOON specification?
+        If yes, please reference the relevant section.
+      placeholder: This relates to SPEC.md section...
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Any other context, mockups, or examples

--- a/.github/ISSUE_TEMPLATE/spec_compliance.yml
+++ b/.github/ISSUE_TEMPLATE/spec_compliance.yml
@@ -1,0 +1,66 @@
+name: SPEC Compliance Issue
+description: Report a deviation from the TOON specification
+labels: ["spec-compliance"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Report an issue where toon-rust doesn't comply with the official TOON spec.
+
+  - type: input
+    id: spec-version
+    attributes:
+      label: SPEC Version
+      description: Which version of the TOON spec does this relate to?
+      placeholder: v1.3
+    validations:
+      required: true
+
+  - type: input
+    id: spec-section
+    attributes:
+      label: SPEC Section
+      description: Which section of SPEC.md is affected?
+      placeholder: "Section 2.3: Array Notation"
+    validations:
+      required: true
+
+  - type: textarea
+    id: spec-requirement
+    attributes:
+      label: SPEC Requirement
+      description: What does the spec require?
+      placeholder: According to SPEC.md, the encoder should...
+    validations:
+      required: true
+
+  - type: textarea
+    id: current-behavior
+    attributes:
+      label: Current Behavior
+      description: What does toon-rust currently do?
+      placeholder: Currently, toon-rust...
+    validations:
+      required: true
+
+  - type: textarea
+    id: test-case
+    attributes:
+      label: Test Case
+      description: Provide a test case that demonstrates the issue
+      placeholder: |
+        ```rust
+        use somo::encode;
+
+        let result = encode(...);
+        // Expected: ...
+        // Actual: ...
+        ```
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Any other relevant information

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,62 @@
+## Description
+
+<!-- Provide a clear and concise description of your changes -->
+
+## Type of Change
+
+<!-- Mark the relevant option with an [x] -->
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+- [ ] Refactoring (no functional changes)
+- [ ] Performance improvement
+- [ ] Test coverage improvement
+
+## Related Issues
+
+<!-- Link any related issues using #issue_number -->
+
+Closes #
+
+## Changes Made
+
+<!-- List the main changes in this PR -->
+
+-
+-
+-
+
+## SPEC Compliance
+
+<!-- If this PR relates to the TOON spec, indicate which sections are affected -->
+
+- [ ] This PR implements/fixes spec compliance
+- [ ] Spec section(s) affected:
+- [ ] Spec version:
+
+## Testing
+
+<!-- Describe the tests you added or ran -->
+
+- [ ] All existing tests pass (`cargo test`)
+- [ ] Added new tests for changes
+- [ ] Tested with stable Rust toolchain
+- [ ] Tested with beta Rust toolchain
+- [ ] Tested with nightly Rust toolchain
+
+## Checklist
+
+<!-- Mark completed items with an [x] -->
+
+- [ ] My code follows the project's coding standards
+- [ ] I have run `cargo fmt` and `cargo clippy`
+- [ ] I have added tests that prove my fix/feature works
+- [ ] New and existing tests pass locally
+- [ ] I have updated documentation (if needed)
+- [ ] My changes do not introduce new dependencies
+
+## Additional Context
+
+<!-- Add any other context about the PR here (optional) -->

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,30 @@
+name: Lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  lint:
+    name: Lint and Format Check
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Run cargo format
+        run: cargo fmt -- --check
+
+      - name: Run cargo clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,24 @@
+name: Publish to crates.io
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    name: Publish to crates.io
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Publish to crates.io
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+        run: cargo publish --no-verify

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  test:
+    name: Rust on ${{ matrix.os }} (stable)
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Run tests
+        run: cargo test --all --verbose


### PR DESCRIPTION
Hey, in case no one was working on this yet:

This PR adds a basic CI pipeline for linting, testing and publishing to `crates.io`. I also added files for issue templates, codeowners, etc. the same way you did for `toon-python`. I just changed python-specific things to be rust-specific.