### PR TITLE
feat(layout): expose decoder layout metadata behind cargo feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,9 @@ required-features = ["cli"]
 [features]
 default = ["cli"]
 json_stream = []
+# Expose decoder layout metadata via `decode_with_layout`. Experimental:
+# scoped to schema/tooling exploration, not part of the TOON specification.
+layout = []
 cli = [
     "dep:clap",
     "dep:anyhow",

--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ users[2]{id,name}:
 - **Strict Validation**: Enforces all spec rules (configurable)
 - **Well-Tested**: Comprehensive test suite with unit tests, spec fixtures, and real-world scenarios
 
+### Experimental Cargo Features
+
+- **`layout`** *(experimental, off by default)*: Exposes decoder layout metadata
+  (tabular vs list vs inline, declared `[N]` lengths, field descriptors) via
+  `decode_with_layout`. Scoped to independent exploration of schema and tooling
+  use cases (validators, formatters, linters); **not part of the TOON
+  specification** and may evolve independently of the core decoder.
+
 ## Installation
 
 ### As a Library

--- a/src/decode/layout_builder.rs
+++ b/src/decode/layout_builder.rs
@@ -1,0 +1,113 @@
+use crate::layout::{
+    Layout,
+    NodeLayout,
+};
+
+pub(crate) struct LayoutBuilder {
+    stack: Vec<String>,
+    layout: Layout,
+}
+
+impl LayoutBuilder {
+    pub fn new() -> Self {
+        Self {
+            stack: Vec::new(),
+            layout: Layout::new(),
+        }
+    }
+
+    pub fn push(&mut self, segment: impl Into<String>) {
+        self.stack.push(segment.into());
+    }
+
+    pub fn pop(&mut self) {
+        self.stack.pop();
+    }
+
+    pub fn record(&mut self, node: NodeLayout) {
+        self.layout.insert(self.current_path(), node);
+    }
+
+    pub fn finish(self) -> Layout {
+        self.layout
+    }
+
+    fn current_path(&self) -> String {
+        if self.stack.is_empty() {
+            return String::new();
+        }
+        let mut out = String::with_capacity(self.stack.iter().map(|s| s.len() + 1).sum());
+        for segment in &self.stack {
+            out.push('/');
+            for ch in segment.chars() {
+                match ch {
+                    '~' => out.push_str("~0"),
+                    '/' => out.push_str("~1"),
+                    _ => out.push(ch),
+                }
+            }
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::Delimiter;
+
+    #[test]
+    fn root_path_is_empty() {
+        let b = LayoutBuilder::new();
+        assert_eq!(b.current_path(), "");
+    }
+
+    #[test]
+    fn path_joins_segments_with_slash() {
+        let mut b = LayoutBuilder::new();
+        b.push("users");
+        b.push("0");
+        b.push("name");
+        assert_eq!(b.current_path(), "/users/0/name");
+    }
+
+    #[test]
+    fn path_escapes_rfc6901_specials() {
+        let mut b = LayoutBuilder::new();
+        b.push("a/b");
+        b.push("c~d");
+        assert_eq!(b.current_path(), "/a~1b/c~0d");
+    }
+
+    #[test]
+    fn pop_balances_push() {
+        let mut b = LayoutBuilder::new();
+        b.push("a");
+        b.push("b");
+        b.pop();
+        assert_eq!(b.current_path(), "/a");
+    }
+
+    #[test]
+    fn record_writes_at_current_path() {
+        let mut b = LayoutBuilder::new();
+        b.push("users");
+        b.record(NodeLayout::List { declared_len: 2 });
+        let layout = b.finish();
+        assert_eq!(
+            layout.get("/users"),
+            Some(&NodeLayout::List { declared_len: 2 })
+        );
+    }
+
+    #[test]
+    fn record_root() {
+        let mut b = LayoutBuilder::new();
+        b.record(NodeLayout::InlineArray {
+            declared_len: 3,
+            delimiter: Delimiter::Comma,
+        });
+        let layout = b.finish();
+        assert!(layout.get("").is_some());
+    }
+}

--- a/src/decode/mod.rs
+++ b/src/decode/mod.rs
@@ -1,5 +1,7 @@
 //! Decoder Implementation
 pub mod expansion;
+#[cfg(feature = "layout")]
+pub(crate) mod layout_builder;
 pub mod parser;
 pub mod scanner;
 pub mod validation;
@@ -63,20 +65,25 @@ pub fn decode<T: serde::de::DeserializeOwned>(
 ) -> ToonResult<T> {
     let mut parser = parser::Parser::new(input, options.clone())?;
     let value = parser.parse()?;
+    let final_value = apply_path_expansion(value, options)?;
+    serde_json::from_value(final_value)
+        .map_err(|e| crate::types::ToonError::DeserializationError(e.to_string()))
+}
 
-    // Apply path expansion if enabled (v1.5 feature)
+/// Apply path expansion to a decoded value if enabled in `options`.
+///
+/// Shared by [`decode`] and [`decode_with_layout`] so both paths see the same
+/// post-parse transformation.
+fn apply_path_expansion(value: Value, options: &DecodeOptions) -> ToonResult<Value> {
     use crate::types::PathExpansionMode;
-    let final_value = if options.expand_paths != PathExpansionMode::Off {
+    if options.expand_paths != PathExpansionMode::Off {
         let json_value = crate::types::JsonValue::from(value);
         let expanded =
             expansion::expand_paths_recursive(json_value, options.expand_paths, options.strict)?;
-        Value::from(expanded)
+        Ok(Value::from(expanded))
     } else {
-        value
-    };
-
-    serde_json::from_value(final_value)
-        .map_err(|e| crate::types::ToonError::DeserializationError(e.to_string()))
+        Ok(value)
+    }
 }
 
 /// Decode with strict validation enabled (validates array lengths,
@@ -223,6 +230,50 @@ pub fn decode_no_coerce_with_options<T: serde::de::DeserializeOwned>(
 /// ```
 pub fn decode_default<T: serde::de::DeserializeOwned>(input: &str) -> ToonResult<T> {
     decode(input, &DecodeOptions::default())
+}
+
+/// Decode a TOON document and return the value alongside layout metadata
+/// describing how the document was actually written on the wire.
+///
+/// Available only when the `layout` cargo feature is enabled.
+///
+/// # Pointer semantics with `expand_paths`
+///
+/// JSON pointers in the returned [`Layout`](crate::layout::Layout) reflect
+/// the document's *pre-expansion* structure — i.e. the key names the parser
+/// actually saw on the wire. When `options.expand_paths` is `Safe`, the
+/// returned value is restructured (e.g. `a.b: 1` becomes `{"a": {"b": 1}}`)
+/// but layout pointers still address the original keys. For unambiguous
+/// pointer-to-value lookups, prefer `PathExpansionMode::Off` (the default).
+///
+/// # Examples
+///
+/// ```
+/// use toon_format::{
+///     decode_with_layout,
+///     DecodeOptions,
+///     NodeLayout,
+/// };
+///
+/// let toon = "users[2]{id,name}:\n  1,Alice\n  2,Bob";
+/// let (_value, layout) = decode_with_layout(toon, &DecodeOptions::default())?;
+///
+/// assert!(matches!(
+///     layout.get("/users"),
+///     Some(NodeLayout::Tabular { .. })
+/// ));
+/// # Ok::<(), toon_format::ToonError>(())
+/// ```
+#[cfg(feature = "layout")]
+pub fn decode_with_layout(
+    input: &str,
+    options: &DecodeOptions,
+) -> ToonResult<(Value, crate::layout::Layout)> {
+    let mut parser = parser::Parser::new(input, options.clone())?.with_layout();
+    let value = parser.parse()?;
+    let final_value = apply_path_expansion(value, options)?;
+    let layout = parser.take_layout().unwrap_or_default();
+    Ok((final_value, layout))
 }
 
 #[cfg(test)]

--- a/src/decode/mod.rs
+++ b/src/decode/mod.rs
@@ -237,6 +237,10 @@ pub fn decode_default<T: serde::de::DeserializeOwned>(input: &str) -> ToonResult
 ///
 /// Available only when the `layout` cargo feature is enabled.
 ///
+/// **Experimental.** This API supports independent exploration of schema
+/// and tooling use cases and is not part of the TOON specification.
+/// See [`crate::layout`] for the metadata types.
+///
 /// # Pointer semantics with `expand_paths`
 ///
 /// JSON pointers in the returned [`Layout`](crate::layout::Layout) reflect

--- a/src/decode/parser.rs
+++ b/src/decode/parser.rs
@@ -26,6 +26,15 @@ use crate::{
     },
     utils::validation::validate_depth,
 };
+#[cfg(feature = "layout")]
+use crate::{
+    decode::layout_builder::LayoutBuilder,
+    layout::{
+        FieldDescriptor,
+        Layout,
+        NodeLayout,
+    },
+};
 
 /// Context for parsing arrays to determine correct indentation depth.
 ///
@@ -50,6 +59,8 @@ pub struct Parser<'a> {
     options: DecodeOptions,
     delimiter: Option<Delimiter>,
     input: &'a str,
+    #[cfg(feature = "layout")]
+    layout: Option<LayoutBuilder>,
 }
 
 impl<'a> Parser<'a> {
@@ -66,7 +77,74 @@ impl<'a> Parser<'a> {
             delimiter: chosen_delim,
             options,
             input,
+            #[cfg(feature = "layout")]
+            layout: None,
         })
+    }
+
+    #[cfg(feature = "layout")]
+    pub fn with_layout(mut self) -> Self {
+        self.layout = Some(LayoutBuilder::new());
+        self
+    }
+
+    #[cfg(feature = "layout")]
+    pub fn take_layout(&mut self) -> Option<Layout> {
+        self.layout.take().map(LayoutBuilder::finish)
+    }
+
+    fn layout_push(&mut self, segment: &str) {
+        #[cfg(feature = "layout")]
+        if let Some(b) = self.layout.as_mut() {
+            b.push(segment.to_string());
+        }
+        #[cfg(not(feature = "layout"))]
+        let _ = segment;
+    }
+
+    fn layout_pop(&mut self) {
+        #[cfg(feature = "layout")]
+        if let Some(b) = self.layout.as_mut() {
+            b.pop();
+        }
+    }
+
+    fn layout_record_tabular(&mut self, length: usize, fields: &[String], delimiter: Delimiter) {
+        #[cfg(feature = "layout")]
+        if let Some(b) = self.layout.as_mut() {
+            let descriptors: Vec<FieldDescriptor> =
+                fields.iter().map(FieldDescriptor::leaf).collect();
+            b.record(NodeLayout::Tabular {
+                declared_len: length,
+                fields: descriptors,
+                delimiter,
+            });
+        }
+        #[cfg(not(feature = "layout"))]
+        let _ = (length, fields, delimiter);
+    }
+
+    fn layout_record_list(&mut self, length: usize) {
+        #[cfg(feature = "layout")]
+        if let Some(b) = self.layout.as_mut() {
+            b.record(NodeLayout::List {
+                declared_len: length,
+            });
+        }
+        #[cfg(not(feature = "layout"))]
+        let _ = length;
+    }
+
+    fn layout_record_inline_array(&mut self, length: usize, delimiter: Delimiter) {
+        #[cfg(feature = "layout")]
+        if let Some(b) = self.layout.as_mut() {
+            b.record(NodeLayout::InlineArray {
+                declared_len: length,
+                delimiter,
+            });
+        }
+        #[cfg(not(feature = "layout"))]
+        let _ = (length, delimiter);
     }
 
     /// Parse the input into a JSON value.
@@ -330,6 +408,7 @@ impl<'a> Parser<'a> {
             };
             self.advance()?;
 
+            self.layout_push(&key);
             let value = if matches!(self.current_token, Token::LeftBracket) {
                 self.parse_array(depth)?
             } else {
@@ -344,6 +423,7 @@ impl<'a> Parser<'a> {
                 self.advance()?;
                 self.parse_field_value(depth)?
             };
+            self.layout_pop();
 
             obj.insert(key, value);
         }
@@ -363,8 +443,10 @@ impl<'a> Parser<'a> {
             self.validate_indentation(current_indent)?;
         }
 
+        self.layout_push(&key);
         if matches!(self.current_token, Token::LeftBracket) {
             let value = self.parse_array(depth)?;
+            self.layout_pop();
             obj.insert(key, value);
         } else {
             if !matches!(self.current_token, Token::Colon) {
@@ -376,6 +458,7 @@ impl<'a> Parser<'a> {
             self.advance()?;
 
             let value = self.parse_field_value(depth)?;
+            self.layout_pop();
             obj.insert(key, value);
         }
 
@@ -458,15 +541,18 @@ impl<'a> Parser<'a> {
             };
             self.advance()?;
 
+            self.layout_push(&key);
             let value = if matches!(self.current_token, Token::LeftBracket) {
                 self.parse_array(depth)?
             } else {
                 if !matches!(self.current_token, Token::Colon) {
+                    self.layout_pop();
                     break;
                 }
                 self.advance()?;
                 self.parse_field_value(depth)?
             };
+            self.layout_pop();
 
             obj.insert(key, value);
         }
@@ -706,10 +792,12 @@ impl<'a> Parser<'a> {
     ) -> ToonResult<Value> {
         validate_depth(depth, MAX_DEPTH)?;
 
-        let (length, _detected_delim, fields) = self.parse_array_header()?;
+        let (length, detected_delim, fields) = self.parse_array_header()?;
+        let delim = detected_delim.unwrap_or(Delimiter::Comma);
 
         if let Some(fields) = fields {
             validation::validate_field_list(&fields)?;
+            self.layout_record_tabular(length, &fields, delim);
             self.parse_tabular_array(length, &fields, depth, context)
         } else {
             // Non-tabular arrays as first field of list items require depth adjustment
@@ -718,6 +806,11 @@ impl<'a> Parser<'a> {
                 ArrayParseContext::Normal => depth,
                 ArrayParseContext::ListItemFirstField => depth + 1,
             };
+            if length == 0 || matches!(self.current_token, Token::Newline) {
+                self.layout_record_list(length);
+            } else {
+                self.layout_record_inline_array(length, delim);
+            }
             self.parse_regular_array(length, adjusted_depth)
         }
     }
@@ -952,6 +1045,9 @@ impl<'a> Parser<'a> {
                     }
                     self.advance()?;
 
+                    let item_path = i.to_string();
+                    self.layout_push(&item_path);
+
                     let value = if matches!(self.current_token, Token::Newline | Token::Eof) {
                         Value::Object(Map::new())
                     } else if matches!(self.current_token, Token::LeftBracket) {
@@ -964,6 +1060,7 @@ impl<'a> Parser<'a> {
                             // This is an object: key followed by colon or array bracket
                             // First field of list-item object may be an array requiring special
                             // indentation
+                            self.layout_push(&key);
                             let first_value = if matches!(self.current_token, Token::LeftBracket) {
                                 // Array directly after key (e.g., "- key[N]:")
                                 // Use ListItemFirstField context to apply correct indentation
@@ -982,6 +1079,7 @@ impl<'a> Parser<'a> {
                                     self.parse_field_value(depth + 2)?
                                 }
                             };
+                            self.layout_pop();
 
                             let mut obj = Map::new();
                             obj.insert(key, first_value);
@@ -1035,6 +1133,7 @@ impl<'a> Parser<'a> {
                                     };
                                     self.advance()?;
 
+                                    self.layout_push(&field_key);
                                     let field_value =
                                         if matches!(self.current_token, Token::LeftBracket) {
                                             self.parse_array(depth + 2)?
@@ -1046,8 +1145,10 @@ impl<'a> Parser<'a> {
                                                 self.parse_field_value(depth + 2)?
                                             }
                                         } else {
+                                            self.layout_pop();
                                             break;
                                         };
+                                    self.layout_pop();
 
                                     obj.insert(field_key, field_value);
 
@@ -1088,6 +1189,7 @@ impl<'a> Parser<'a> {
                         self.parse_primitive()?
                     };
 
+                    self.layout_pop();
                     items.push(value);
 
                     if items.len() < length {

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -8,6 +8,11 @@
 //!
 //! Available only when the `layout` cargo feature is enabled.
 //!
+//! **Experimental.** This module supports independent exploration of schema
+//! and tooling use cases (validators, formatters, linters). It is not part
+//! of the TOON specification and its API may evolve independently of the
+//! core decoder.
+//!
 //! # Example
 //!
 //! ```

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -1,0 +1,119 @@
+//! Decoder layout metadata.
+//!
+//! [`Layout`] captures structural information about how a TOON document was
+//! encoded on the wire — information that is otherwise lost once decoded into
+//! a [`serde_json::Value`].
+//!
+//! Obtain a `Layout` via [`crate::decode::decode_with_layout`].
+//!
+//! Available only when the `layout` cargo feature is enabled.
+//!
+//! # Example
+//!
+//! ```
+//! # #[cfg(feature = "layout")]
+//! # fn main() -> Result<(), toon_format::ToonError> {
+//! use toon_format::{
+//!     decode_with_layout,
+//!     DecodeOptions,
+//! };
+//!
+//! let toon = "users[2]{id,name}:\n  1,Alice\n  2,Bob";
+//! let (_value, layout) = decode_with_layout(toon, &DecodeOptions::default())?;
+//!
+//! assert!(matches!(
+//!     layout.get("/users"),
+//!     Some(toon_format::NodeLayout::Tabular { .. })
+//! ));
+//! # Ok(())
+//! # }
+//! # #[cfg(not(feature = "layout"))]
+//! # fn main() {}
+//! ```
+
+use std::collections::BTreeMap;
+
+use crate::types::Delimiter;
+
+/// Layout metadata for a decoded TOON document, keyed by JSON Pointer
+/// (RFC 6901). The empty pointer `""` refers to the document root. Only
+/// nodes with layout-relevant information are present; primitive scalars
+/// are not recorded.
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct Layout {
+    nodes: BTreeMap<String, NodeLayout>,
+}
+
+impl Layout {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Look up the layout at a JSON Pointer. Use `""` for the document root.
+    pub fn get(&self, json_pointer: &str) -> Option<&NodeLayout> {
+        self.nodes.get(json_pointer)
+    }
+
+    /// Iterate `(json_pointer, node_layout)` pairs sorted by pointer.
+    pub fn iter(&self) -> impl Iterator<Item = (&str, &NodeLayout)> {
+        self.nodes.iter().map(|(k, v)| (k.as_str(), v))
+    }
+
+    pub fn len(&self) -> usize {
+        self.nodes.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.nodes.is_empty()
+    }
+
+    pub(crate) fn insert(&mut self, json_pointer: String, node: NodeLayout) {
+        self.nodes.insert(json_pointer, node);
+    }
+}
+
+/// Per-node layout describing how a value was written in the source TOON.
+///
+/// Only array-shaped nodes are recorded in this release. Object key order
+/// and key-folding metadata are planned for a follow-up.
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq)]
+pub enum NodeLayout {
+    /// Tabular array: `key[N]{f1,f2,...}:` with rows on subsequent lines.
+    Tabular {
+        declared_len: usize,
+        fields: Vec<FieldDescriptor>,
+        delimiter: Delimiter,
+    },
+
+    /// List-form array: `key[N]:` followed by `- item` lines.
+    List { declared_len: usize },
+
+    /// Inline primitive array: `key[N]: a,b,c` on a single line.
+    InlineArray {
+        declared_len: usize,
+        delimiter: Delimiter,
+    },
+}
+
+/// A field declared in a tabular array header.
+///
+/// `nested` is reserved for forward compatibility with proposals that allow
+/// tabular fields to contain nested object schemas (e.g. spec RFC #46). For
+/// TOON v3.0 it is always `None`.
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq)]
+pub struct FieldDescriptor {
+    pub name: String,
+    pub nested: Option<Box<NodeLayout>>,
+}
+
+impl FieldDescriptor {
+    pub fn leaf(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            nested: None,
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,11 +28,15 @@
 pub mod constants;
 pub mod decode;
 pub mod encode;
+#[cfg(feature = "layout")]
+pub mod layout;
 #[cfg(feature = "cli")]
 pub mod tui;
 pub mod types;
 pub mod utils;
 
+#[cfg(feature = "layout")]
+pub use decode::decode_with_layout;
 pub use decode::{
     decode,
     decode_default,
@@ -54,6 +58,12 @@ pub use encode::{
     encode_array,
     encode_default,
     encode_object,
+};
+#[cfg(feature = "layout")]
+pub use layout::{
+    FieldDescriptor,
+    Layout,
+    NodeLayout,
 };
 pub use types::{
     DecodeOptions,

--- a/tests/layout.rs
+++ b/tests/layout.rs
@@ -1,0 +1,171 @@
+#![cfg(feature = "layout")]
+
+use toon_format::{
+    decode_with_layout,
+    DecodeOptions,
+    Delimiter,
+    FieldDescriptor,
+    NodeLayout,
+};
+
+fn decode(input: &str) -> (serde_json::Value, toon_format::Layout) {
+    decode_with_layout(input, &DecodeOptions::default()).expect("decode_with_layout failed")
+}
+
+#[test]
+fn tabular_array_records_fields_and_delimiter() {
+    let (_value, layout) = decode("users[2]{id,name}:\n  1,Alice\n  2,Bob");
+
+    let node = layout.get("/users").expect("/users should be recorded");
+    assert_eq!(
+        node,
+        &NodeLayout::Tabular {
+            declared_len: 2,
+            fields: vec![FieldDescriptor::leaf("id"), FieldDescriptor::leaf("name")],
+            delimiter: Delimiter::Comma,
+        }
+    );
+}
+
+#[test]
+fn list_form_array_records_declared_length() {
+    let (_value, layout) = decode("items[2]:\n  - a\n  - b");
+    assert_eq!(
+        layout.get("/items"),
+        Some(&NodeLayout::List { declared_len: 2 })
+    );
+}
+
+#[test]
+fn inline_array_records_delimiter() {
+    let (_value, layout) = decode("tags[3]: reading,gaming,coding");
+    assert_eq!(
+        layout.get("/tags"),
+        Some(&NodeLayout::InlineArray {
+            declared_len: 3,
+            delimiter: Delimiter::Comma,
+        })
+    );
+}
+
+#[test]
+fn empty_array_records_as_list_with_zero_length() {
+    let (_value, layout) = decode("items[0]:");
+    assert_eq!(
+        layout.get("/items"),
+        Some(&NodeLayout::List { declared_len: 0 })
+    );
+}
+
+#[test]
+fn alternative_delimiter_is_recorded() {
+    let (_value, layout) = decode("tags[3|]: a|b|c");
+    assert_eq!(
+        layout.get("/tags"),
+        Some(&NodeLayout::InlineArray {
+            declared_len: 3,
+            delimiter: Delimiter::Pipe,
+        })
+    );
+}
+
+#[test]
+fn root_level_inline_array_records_at_empty_pointer() {
+    let (_value, layout) = decode("[2]: a,b");
+    assert_eq!(
+        layout.get(""),
+        Some(&NodeLayout::InlineArray {
+            declared_len: 2,
+            delimiter: Delimiter::Comma,
+        })
+    );
+}
+
+#[test]
+fn root_level_tabular_records_at_empty_pointer() {
+    let (_value, layout) = decode("[2]{id,name}:\n  1,Alice\n  2,Bob");
+    assert!(matches!(
+        layout.get(""),
+        Some(NodeLayout::Tabular {
+            declared_len: 2,
+            ..
+        })
+    ));
+}
+
+#[test]
+fn nested_array_inside_list_item_object() {
+    let input = "items[1]:\n  - users[2]{id,name}:\n      1,Alice\n      2,Bob";
+    let (_value, layout) = decode(input);
+
+    assert_eq!(
+        layout.get("/items"),
+        Some(&NodeLayout::List { declared_len: 1 })
+    );
+    assert!(matches!(
+        layout.get("/items/0/users"),
+        Some(NodeLayout::Tabular {
+            declared_len: 2,
+            ..
+        })
+    ));
+}
+
+#[test]
+fn nested_inline_array_under_object_key() {
+    let input = "outer:\n  inner[3]: a,b,c";
+    let (_value, layout) = decode(input);
+
+    assert_eq!(
+        layout.get("/outer/inner"),
+        Some(&NodeLayout::InlineArray {
+            declared_len: 3,
+            delimiter: Delimiter::Comma,
+        })
+    );
+}
+
+#[test]
+fn rfc6901_special_chars_escaped_in_pointer() {
+    let input = "\"a/b\":\n  inner[2]: x,y";
+    let (_value, layout) = decode(input);
+    assert!(layout.get("/a~1b/inner").is_some());
+}
+
+#[test]
+fn multiple_arrays_at_root_object() {
+    let input = "users[2]{id,name}:\n  1,Alice\n  2,Bob\ntags[2]: red,blue";
+    let (_value, layout) = decode(input);
+
+    assert!(matches!(
+        layout.get("/users"),
+        Some(NodeLayout::Tabular { .. })
+    ));
+    assert!(matches!(
+        layout.get("/tags"),
+        Some(NodeLayout::InlineArray { .. })
+    ));
+    assert_eq!(layout.len(), 2);
+}
+
+#[test]
+fn no_layout_recorded_for_pure_objects() {
+    let (_value, layout) = decode("name: Alice\nage: 30");
+    assert!(layout.is_empty());
+}
+
+#[test]
+fn iter_yields_pointer_and_node_pairs() {
+    let (_value, layout) = decode("a[1]: x\nb[1]: y");
+    let collected: Vec<&str> = layout.iter().map(|(p, _)| p).collect();
+    assert_eq!(collected, vec!["/a", "/b"]);
+}
+
+#[test]
+fn decode_without_layout_is_unaffected() {
+    use toon_format::decode_default;
+
+    let value: serde_json::Value =
+        decode_default("users[2]{id,name}:\n  1,Alice\n  2,Bob").unwrap();
+    assert_eq!(value["users"][0]["name"], "Alice");
+}


### PR DESCRIPTION
## Summary

Adds an opt-in `layout` cargo feature exposing structural metadata about how a TOON document was actually written on the wire — tabular vs. list vs. inline arrays, declared `[N]` lengths, declared field lists, and active delimiters. Useful for downstream tools (validators, linters, formatters) that need to reason about wire shape and not just the decoded value.

## API surface (additive only)

```rust
// off by default — zero impact on existing callers
pub fn decode_with_layout(input: &str, options: &DecodeOptions)
    -> ToonResult<(serde_json::Value, Layout)>;

#[non_exhaustive] pub struct Layout { /* opaque, JSON-Pointer-keyed */ }
#[non_exhaustive] pub enum NodeLayout { Tabular { .. }, List { .. }, InlineArray { .. } }
#[non_exhaustive] pub struct FieldDescriptor { name, nested }
```

Layout entries are keyed by JSON Pointer (RFC 6901), with `""` for the document root. All public types use `#[non_exhaustive]` so future additions don't break semver.

## Scope

Object key-order and key-folding metadata are intentionally deferred to a follow-up to keep this PR small. `FieldDescriptor::nested` is reserved for forward compatibility with proposals like spec RFC #46 (nested tabular headers) and is always `None` today.

The interaction with `expand_paths` is documented on `decode_with_layout`: pointers reflect pre-expansion structure.