### PR TITLE
Fix: Deserialization failure for u64 values larger than i64::MAX

### DIFF
--- a/src/decode/parser.rs
+++ b/src/decode/parser.rs
@@ -1,12 +1,29 @@
-use serde_json::{Map, Number, Value};
+use serde_json::{
+    Map,
+    Number,
+    Value,
+};
 
 use crate::{
-    constants::{KEYWORDS, MAX_DEPTH, QUOTED_KEY_MARKER},
+    constants::{
+        KEYWORDS,
+        MAX_DEPTH,
+        QUOTED_KEY_MARKER,
+    },
     decode::{
-        scanner::{Scanner, Token},
+        scanner::{
+            Scanner,
+            Token,
+        },
         validation,
     },
-    types::{DecodeOptions, Delimiter, ErrorContext, ToonError, ToonResult},
+    types::{
+        DecodeOptions,
+        Delimiter,
+        ErrorContext,
+        ToonError,
+        ToonResult,
+    },
     utils::validation::validate_depth,
 };
 
@@ -1560,7 +1577,10 @@ mod tests {
 
     #[test]
     fn test_round_trip_parentheses() {
-        use crate::{decode::decode_default, encode::encode_default};
+        use crate::{
+            decode::decode_default,
+            encode::encode_default,
+        };
 
         let original = json!({
             "message": "Mostly Functions (3 of 3)",

--- a/src/decode/parser.rs
+++ b/src/decode/parser.rs
@@ -1300,6 +1300,11 @@ impl<'a> Parser<'a> {
                 self.advance()?;
                 Ok(Number::from(val).into())
             }
+            Token::UnsignedInteger(i) => {
+                let val = *i;
+                self.advance()?;
+                Ok(Number::from(val).into())
+            }
             Token::Number(n) => {
                 let val = *n;
                 self.advance()?;

--- a/src/decode/parser.rs
+++ b/src/decode/parser.rs
@@ -1,29 +1,12 @@
-use serde_json::{
-    Map,
-    Number,
-    Value,
-};
+use serde_json::{Map, Number, Value};
 
 use crate::{
-    constants::{
-        KEYWORDS,
-        MAX_DEPTH,
-        QUOTED_KEY_MARKER,
-    },
+    constants::{KEYWORDS, MAX_DEPTH, QUOTED_KEY_MARKER},
     decode::{
-        scanner::{
-            Scanner,
-            Token,
-        },
+        scanner::{Scanner, Token},
         validation,
     },
-    types::{
-        DecodeOptions,
-        Delimiter,
-        ErrorContext,
-        ToonError,
-        ToonResult,
-    },
+    types::{DecodeOptions, Delimiter, ErrorContext, ToonError, ToonResult},
     utils::validation::validate_depth,
 };
 
@@ -142,7 +125,7 @@ impl<'a> Parser<'a> {
                     Ok(Value::Bool(val))
                 }
             }
-            Token::Integer(i) => {
+            Token::SignedInteger(i) => {
                 let next_char_is_colon = matches!(self.scanner.peek(), Some(':'));
                 if next_char_is_colon {
                     let key = i.to_string();
@@ -155,13 +138,54 @@ impl<'a> Parser<'a> {
                     // Check if followed by more value tokens on the same line
                     match &self.current_token {
                         Token::String(..)
-                        | Token::Integer(..)
+                        | Token::SignedInteger(..)
+                        | Token::UnsignedInteger(..)
                         | Token::Number(..)
                         | Token::Bool(..)
                         | Token::Null => {
                             let mut accumulated = first_text;
                             while let Token::String(..)
-                            | Token::Integer(..)
+                            | Token::SignedInteger(..)
+                            | Token::UnsignedInteger(..)
+                            | Token::Number(..)
+                            | Token::Bool(..)
+                            | Token::Null = &self.current_token
+                            {
+                                let ws = self.scanner.last_whitespace_count().max(1);
+                                for _ in 0..ws {
+                                    accumulated.push(' ');
+                                }
+                                accumulated.push_str(self.scanner.last_token_text());
+                                self.advance()?;
+                            }
+                            Ok(Value::String(accumulated))
+                        }
+                        _ => Ok(serde_json::Number::from(val).into()),
+                    }
+                }
+            }
+            Token::UnsignedInteger(i) => {
+                let next_char_is_colon = matches!(self.scanner.peek(), Some(':'));
+                if next_char_is_colon {
+                    let key = i.to_string();
+                    self.advance()?;
+                    self.parse_object_with_initial_key(key, depth)
+                } else {
+                    let first_text = self.scanner.last_token_text().to_string();
+                    let val = *i;
+                    self.advance()?;
+                    // Check if followed by more value tokens on the same line
+                    match &self.current_token {
+                        Token::String(..)
+                        | Token::SignedInteger(..)
+                        | Token::UnsignedInteger(..)
+                        | Token::Number(..)
+                        | Token::Bool(..)
+                        | Token::Null => {
+                            let mut accumulated = first_text;
+                            while let Token::String(..)
+                            | Token::SignedInteger(..)
+                            | Token::UnsignedInteger(..)
                             | Token::Number(..)
                             | Token::Bool(..)
                             | Token::Null = &self.current_token
@@ -192,13 +216,15 @@ impl<'a> Parser<'a> {
                     // Check if followed by more value tokens on the same line
                     match &self.current_token {
                         Token::String(..)
-                        | Token::Integer(..)
+                        | Token::SignedInteger(..)
+                        | Token::UnsignedInteger(..)
                         | Token::Number(..)
                         | Token::Bool(..)
                         | Token::Null => {
                             let mut accumulated = first_text;
                             while let Token::String(..)
-                            | Token::Integer(..)
+                            | Token::SignedInteger(..)
+                            | Token::UnsignedInteger(..)
                             | Token::Number(..)
                             | Token::Bool(..)
                             | Token::Null = &self.current_token
@@ -256,7 +282,8 @@ impl<'a> Parser<'a> {
                         // Root-level string value - join consecutive tokens with exact spacing
                         let mut accumulated = first;
                         while let Token::String(..)
-                        | Token::Integer(..)
+                        | Token::SignedInteger(..)
+                        | Token::UnsignedInteger(..)
                         | Token::Number(..)
                         | Token::Bool(..)
                         | Token::Null = &self.current_token
@@ -502,7 +529,8 @@ impl<'a> Parser<'a> {
                 // Single token - convert directly to avoid redundant parsing
                 match &self.current_token {
                     Token::String(s, _) => Ok(Value::String(s.clone())),
-                    Token::Integer(i) => Ok(serde_json::Number::from(*i).into()),
+                    Token::SignedInteger(i) => Ok(serde_json::Number::from(*i).into()),
+                    Token::UnsignedInteger(i) => Ok(serde_json::Number::from(*i).into()),
                     Token::Number(n) => {
                         let val = *n;
                         if val.is_finite() && val.fract() == 0.0 && val.abs() <= i64::MAX as f64 {
@@ -527,7 +555,8 @@ impl<'a> Parser<'a> {
                         token_text.clone()
                     }
                     Token::String(_, false)
-                    | Token::Integer(_)
+                    | Token::SignedInteger(_)
+                    | Token::UnsignedInteger(_)
                     | Token::Number(_)
                     | Token::Bool(_)
                     | Token::Null => token_text.clone(),
@@ -545,7 +574,8 @@ impl<'a> Parser<'a> {
                 let token = self.scanner.parse_value_string(&value_str)?;
                 match token {
                     Token::String(s, _) => Ok(Value::String(s)),
-                    Token::Integer(i) => Ok(serde_json::Number::from(i).into()),
+                    Token::SignedInteger(i) => Ok(serde_json::Number::from(i).into()),
+                    Token::UnsignedInteger(i) => Ok(serde_json::Number::from(i).into()),
                     Token::Number(n) => {
                         if n.is_finite() && n.fract() == 0.0 && n.abs() <= i64::MAX as f64 {
                             Ok(serde_json::Number::from(n as i64).into())
@@ -588,7 +618,9 @@ impl<'a> Parser<'a> {
 
         // Parse array length (plain integer only)
         // Supports formats: [N], [N|], [N\t] (no # marker)
-        let length = if let Token::Integer(n) = &self.current_token {
+        let length = if let Token::SignedInteger(n) = &self.current_token {
+            *n as usize
+        } else if let Token::UnsignedInteger(n) = &self.current_token {
             *n as usize
         } else if let Token::String(s, _) = &self.current_token {
             // Check if string starts with # - this marker is not supported
@@ -1182,7 +1214,8 @@ impl<'a> Parser<'a> {
             let result = match &self.current_token {
                 Token::Null => Ok(Value::Null),
                 Token::Bool(b) => Ok(Value::Bool(*b)),
-                Token::Integer(i) => Ok(Number::from(*i).into()),
+                Token::SignedInteger(i) => Ok(Number::from(*i).into()),
+                Token::UnsignedInteger(i) => Ok(Number::from(*i).into()),
                 Token::Number(n) => {
                     let val = *n;
                     if val.is_finite() && val.fract() == 0.0 && val.abs() <= i64::MAX as f64 {
@@ -1216,7 +1249,8 @@ impl<'a> Parser<'a> {
             self.current_token = self.scanner.scan_token()?;
             match token {
                 Token::String(s, _) => Ok(Value::String(s)),
-                Token::Integer(i) => Ok(Number::from(i).into()),
+                Token::SignedInteger(i) => Ok(Number::from(i).into()),
+                Token::UnsignedInteger(i) => Ok(Number::from(i).into()),
                 Token::Number(n) => {
                     if n.is_finite() && n.fract() == 0.0 && n.abs() <= i64::MAX as f64 {
                         Ok(Number::from(n as i64).into())
@@ -1244,7 +1278,7 @@ impl<'a> Parser<'a> {
                 self.advance()?;
                 Ok(Value::Bool(val))
             }
-            Token::Integer(i) => {
+            Token::SignedInteger(i) => {
                 let val = *i;
                 self.advance()?;
                 Ok(Number::from(val).into())
@@ -1526,10 +1560,7 @@ mod tests {
 
     #[test]
     fn test_round_trip_parentheses() {
-        use crate::{
-            decode::decode_default,
-            encode::encode_default,
-        };
+        use crate::{decode::decode_default, encode::encode_default};
 
         let original = json!({
             "message": "Mostly Functions (3 of 3)",

--- a/src/decode/scanner.rs
+++ b/src/decode/scanner.rs
@@ -1,8 +1,4 @@
-use crate::types::{
-    Delimiter,
-    ToonError,
-    ToonResult,
-};
+use crate::types::{Delimiter, ToonError, ToonResult};
 
 /// Tokens produced by the scanner during lexical analysis.
 #[derive(Debug, Clone, PartialEq)]
@@ -16,7 +12,8 @@ pub enum Token {
     Newline,
     String(String, bool),
     Number(f64),
-    Integer(i64),
+    SignedInteger(i64),
+    UnsignedInteger(u64),
     Bool(bool),
     Null,
     Delimiter(Delimiter),
@@ -24,6 +21,7 @@ pub enum Token {
 }
 
 /// Scanner that tokenizes TOON input into a sequence of tokens.
+#[derive(Debug)]
 pub struct Scanner {
     input: Vec<char>,
     position: usize,
@@ -400,7 +398,9 @@ impl Scanner {
                 Ok(Token::String(s.to_string(), false))
             }
         } else if let Ok(i) = s.parse::<i64>() {
-            Ok(Token::Integer(i))
+            Ok(Token::SignedInteger(i))
+        } else if let Ok(i) = s.parse::<u64>() {
+            Ok(Token::UnsignedInteger(i))
         } else {
             Ok(Token::String(s.to_string(), false))
         }
@@ -547,7 +547,9 @@ impl Scanner {
                     return Ok(Token::Number(normalized));
                 }
             } else if let Ok(i) = trimmed.parse::<i64>() {
-                return Ok(Token::Integer(i));
+                return Ok(Token::SignedInteger(i));
+            } else if let Ok(i) = trimmed.parse::<u64>() {
+                return Ok(Token::UnsignedInteger(i));
             }
         }
 
@@ -602,13 +604,14 @@ mod tests {
 
     #[test]
     fn test_scan_numbers() {
-        let mut scanner = Scanner::new("42 3.141592653589793 -5");
-        assert_eq!(scanner.scan_token().unwrap(), Token::Integer(42));
+        let mut scanner = Scanner::new("42 3.141592653589793 -5 12591154125385152738");
+        assert_eq!(scanner.scan_token().unwrap(), Token::SignedInteger(42));
         assert_eq!(
             scanner.scan_token().unwrap(),
             Token::Number(f64::consts::PI)
         );
-        assert_eq!(scanner.scan_token().unwrap(), Token::Integer(-5));
+        assert_eq!(scanner.scan_token().unwrap(), Token::SignedInteger(-5));
+        assert_eq!(scanner.scan_token().unwrap(), Token::UnsignedInteger(12591154125385152738));
     }
 
     #[test]
@@ -717,7 +720,7 @@ mod tests {
 
         assert_eq!(
             scanner.parse_value_string("42").unwrap(),
-            Token::Integer(42)
+            Token::SignedInteger(42)
         );
 
         assert_eq!(

--- a/src/decode/scanner.rs
+++ b/src/decode/scanner.rs
@@ -1,4 +1,8 @@
-use crate::types::{Delimiter, ToonError, ToonResult};
+use crate::types::{
+    Delimiter,
+    ToonError,
+    ToonResult,
+};
 
 /// Tokens produced by the scanner during lexical analysis.
 #[derive(Debug, Clone, PartialEq)]
@@ -611,7 +615,10 @@ mod tests {
             Token::Number(f64::consts::PI)
         );
         assert_eq!(scanner.scan_token().unwrap(), Token::SignedInteger(-5));
-        assert_eq!(scanner.scan_token().unwrap(), Token::UnsignedInteger(12591154125385152738));
+        assert_eq!(
+            scanner.scan_token().unwrap(),
+            Token::UnsignedInteger(12591154125385152738)
+        );
     }
 
     #[test]

--- a/tests/round_trip.rs
+++ b/tests/round_trip.rs
@@ -31,6 +31,12 @@ fn test_comprehensive_round_trips() {
         ]}),
         json!({"empty_array": []}),
         json!({"empty_object": {}}),
+        json!({"large_unsigned_integer": 12591154125385152738_u64}),
+        json!([
+            12591154125385152738_u64,
+            18446744073709551615_u64,
+            9223372036854775808_u64
+        ]),
     ];
 
     for (i, case) in test_cases.iter().enumerate() {


### PR DESCRIPTION
## Linked Issue

Fix: #64 

Closes #

## Description

Issue was during deserialization, u64 values larger than i64::MAX (9223372036854775807) fail because they are incorrectly handled as i64. This causes errors when values exceed the i64 range.

Updated the decoding logic by introducing SignedInteger(i64) and UnsignedInteger(u64) variants, allowing values to be deserialized using the appropriate integer type and correctly handling u64 values larger than i64::MAX.

## Type of Change

<!-- Mark the relevant option with an [x] -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Changes Made

<!-- List the main changes in this PR -->

- Introduced SignedInteger(i64) and UnsignedInteger(u64) variants.
- Updated the decoding logic to use the appropriate integer type during deserialization.

## SPEC Compliance

<!-- If this PR relates to the TOON spec, indicate which sections are affected -->

- [ ] This PR implements/fixes spec compliance
- [ ] Spec section(s) affected:
- [ ] Spec version:

## Testing

<!-- Describe the tests you added or ran -->

- [x] All existing tests pass
- [ ] Added new tests for changes
- [ ] Tests cover edge cases and spec compliance

## Pre-submission Checklist

<!-- Verify before submitting -->

- [x] My code follows the project's coding standards
- [x] I have run code formatting/linting tools
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed
- [ ] I have reviewed the [TOON specification](https://github.com/toon-format/spec) for relevant sections

## Breaking Changes

<!-- If this is a breaking change, describe the migration path for users -->

- [x] No breaking changes
- [ ] Breaking changes (describe migration path below)

<!-- Migration path: -->

## Additional Context

<!-- Add any other context about the PR here (optional) -->
