### PR TITLE
fix: align decoder with TOON v3.3 edge cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 [![Crates.io](https://img.shields.io/crates/v/toon-format.svg)](https://crates.io/crates/toon-format)
 [![Documentation](https://docs.rs/toon-format/badge.svg)](https://docs.rs/toon-format)
-[![Spec v3.0](https://img.shields.io/badge/spec-v3.0-brightgreen.svg)](https://github.com/toon-format/spec/blob/main/SPEC.md)
+[![Spec v3.3](https://img.shields.io/badge/spec-v3.3-brightgreen.svg)](https://github.com/toon-format/spec/blob/main/SPEC.md)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 [![Tests](https://img.shields.io/badge/tests-%20passing-success.svg)]()
 
 **Token-Oriented Object Notation (TOON)** is a compact, human-readable format designed for passing structured data to Large Language Models with significantly reduced token usage.
 
-This crate provides the official, **spec-compliant Rust implementation** of TOON v3.0, offering both a library (`toon-format`) and a full-featured command-line tool (`toon`).
+This crate provides the official, **spec-compliant Rust implementation** of TOON v3.3, offering both a library (`toon-format`) and a full-featured command-line tool (`toon`).
 
 ## Quick Example
 
@@ -32,7 +32,7 @@ users[2]{id,name}:
 ## Features
 
 - **Generic API**: Works with any `Serialize`/`Deserialize` type - custom structs, enums, JSON values, and more
-- **Spec-Compliant**: Fully compliant with [TOON Specification v3.0](https://github.com/toon-format/spec/blob/main/SPEC.md)
+- **Spec-Compliant**: Fully compliant with [TOON Specification v3.3](https://github.com/toon-format/spec/blob/main/SPEC.md)
 - **Key Folding & Path Expansion**: Collapse and expand dotted key paths
 - **Safe & Performant**: Built with safe, fast Rust
 - **Powerful CLI**: Full-featured command-line tool
@@ -579,7 +579,7 @@ Run with `cargo run --example examples` to see all examples:
 
 ## Resources
 
-- 📖 [TOON Specification v3.0](https://github.com/toon-format/spec/blob/main/SPEC.md)
+- 📖 [TOON Specification v3.3](https://github.com/toon-format/spec/blob/main/SPEC.md)
 - 📦 [Crates.io Package](https://crates.io/crates/toon-format)
 - 📚 [API Documentation](https://docs.rs/toon-format)
 - 🔧 [Main Repository (JS/TS)](https://github.com/toon-format/toon)

--- a/src/decode/parser.rs
+++ b/src/decode/parser.rs
@@ -431,7 +431,7 @@ impl<'a> Parser<'a> {
                 base_indent = Some(current_indent);
             }
 
-            let key = match &self.current_token {
+            let mut key = match &self.current_token {
                 Token::String(s, was_quoted) => {
                     // Mark quoted keys containing dots with a special prefix
                     // so path expansion can skip them
@@ -454,7 +454,16 @@ impl<'a> Parser<'a> {
 
             self.layout_push(&key);
             let value = if matches!(self.current_token, Token::LeftBracket) {
-                self.parse_array(depth)?
+                if self.should_fall_back_to_literal_header_key() {
+                    self.layout_pop();
+                    let (literal_key, value) =
+                        self.parse_malformed_header_literal_key_value(key, depth)?;
+                    key = literal_key;
+                    self.layout_push(&key);
+                    value
+                } else {
+                    self.parse_array(depth)?
+                }
             } else {
                 if !matches!(self.current_token, Token::Colon) {
                     return Err(self
@@ -469,6 +478,11 @@ impl<'a> Parser<'a> {
             };
             self.layout_pop();
 
+            if self.options.strict && obj.contains_key(&key) {
+                return Err(self.parse_error_with_context(format!(
+                    "Duplicate sibling key '{key}' is not allowed in strict mode"
+                )));
+            }
             obj.insert(key, value);
         }
 
@@ -478,6 +492,7 @@ impl<'a> Parser<'a> {
     fn parse_object_with_initial_key(&mut self, key: String, depth: usize) -> ToonResult<Value> {
         validate_depth(depth, MAX_DEPTH)?;
 
+        let mut key = key;
         let mut obj = Map::new();
         let mut base_indent: Option<usize> = None;
 
@@ -489,7 +504,16 @@ impl<'a> Parser<'a> {
 
         self.layout_push(&key);
         if matches!(self.current_token, Token::LeftBracket) {
-            let value = self.parse_array(depth)?;
+            let value = if self.should_fall_back_to_literal_header_key() {
+                self.layout_pop();
+                let (literal_key, value) =
+                    self.parse_malformed_header_literal_key_value(key, depth)?;
+                key = literal_key;
+                self.layout_push(&key);
+                value
+            } else {
+                self.parse_array(depth)?
+            };
             self.layout_pop();
             obj.insert(key, value);
         } else {
@@ -571,7 +595,7 @@ impl<'a> Parser<'a> {
                 base_indent = Some(current_indent);
             }
 
-            let key = match &self.current_token {
+            let mut key = match &self.current_token {
                 Token::String(s, was_quoted) => {
                     // Mark quoted keys containing dots with a special prefix
                     // so path expansion can skip them
@@ -587,7 +611,16 @@ impl<'a> Parser<'a> {
 
             self.layout_push(&key);
             let value = if matches!(self.current_token, Token::LeftBracket) {
-                self.parse_array(depth)?
+                if self.should_fall_back_to_literal_header_key() {
+                    self.layout_pop();
+                    let (literal_key, value) =
+                        self.parse_malformed_header_literal_key_value(key, depth)?;
+                    key = literal_key;
+                    self.layout_push(&key);
+                    value
+                } else {
+                    self.parse_array(depth)?
+                }
             } else {
                 if !matches!(self.current_token, Token::Colon) {
                     self.layout_pop();
@@ -598,10 +631,154 @@ impl<'a> Parser<'a> {
             };
             self.layout_pop();
 
+            if self.options.strict && obj.contains_key(&key) {
+                return Err(self.parse_error_with_context(format!(
+                    "Duplicate sibling key '{key}' is not allowed in strict mode"
+                )));
+            }
             obj.insert(key, value);
         }
 
         Ok(Value::Object(obj))
+    }
+
+    fn parse_malformed_header_literal_key_value(
+        &mut self,
+        mut key: String,
+        depth: usize,
+    ) -> ToonResult<(String, Value)> {
+        if !matches!(self.current_token, Token::LeftBracket) {
+            return Err(self.parse_error_with_context("Expected malformed header bracket"));
+        }
+
+        key.push('[');
+        let mut in_quotes = false;
+        let mut escaped = false;
+        while let Some(ch) = self.scanner.advance() {
+            if escaped {
+                key.push(ch);
+                escaped = false;
+                continue;
+            }
+            if ch == '\\' && in_quotes {
+                key.push(ch);
+                escaped = true;
+                continue;
+            }
+            if ch == '"' {
+                key.push(ch);
+                in_quotes = !in_quotes;
+                continue;
+            }
+            if ch == '\n' {
+                return Err(
+                    self.parse_error_with_context("Expected ':' after malformed header key")
+                );
+            }
+            if ch == ':' && !in_quotes {
+                self.current_token = self.scanner.scan_token()?;
+                let value = self.parse_field_value(depth)?;
+                return Ok((key, value));
+            }
+            key.push(ch);
+        }
+
+        Err(self.parse_error_with_context("Expected ':' after malformed header key"))
+    }
+
+    fn should_fall_back_to_literal_header_key(&mut self) -> bool {
+        if self.options.strict || !matches!(self.current_token, Token::LeftBracket) {
+            return false;
+        }
+
+        let checkpoint = self.scanner.checkpoint();
+        let mut segment = String::new();
+        let mut saw_colon = false;
+        let mut in_quotes = false;
+        let mut escaped = false;
+
+        while let Some(ch) = self.scanner.advance() {
+            if escaped {
+                segment.push(ch);
+                escaped = false;
+                continue;
+            }
+            if ch == '\\' && in_quotes {
+                segment.push(ch);
+                escaped = true;
+                continue;
+            }
+            if ch == '"' {
+                segment.push(ch);
+                in_quotes = !in_quotes;
+                continue;
+            }
+            if ch == '\n' {
+                break;
+            }
+            if ch == ':' && !in_quotes {
+                saw_colon = true;
+                break;
+            }
+            segment.push(ch);
+        }
+
+        self.scanner.restore(checkpoint);
+
+        saw_colon && !Self::is_canonical_array_header_segment(&segment)
+    }
+
+    fn is_canonical_array_header_segment(segment: &str) -> bool {
+        let Some(close_bracket_index) = Self::find_unquoted_char(segment, ']') else {
+            return false;
+        };
+
+        let raw_length = &segment[..close_bracket_index];
+        let suffix = &segment[close_bracket_index + 1..];
+        let length = raw_length
+            .strip_suffix([',', '|', '\t'])
+            .unwrap_or(raw_length);
+
+        if !Self::is_canonical_array_length(length) {
+            return false;
+        }
+
+        if suffix.is_empty() {
+            return true;
+        }
+
+        suffix.starts_with('{') && suffix.ends_with('}')
+    }
+
+    fn find_unquoted_char(input: &str, target: char) -> Option<usize> {
+        let mut in_quotes = false;
+        let mut escaped = false;
+
+        for (index, ch) in input.char_indices() {
+            if escaped {
+                escaped = false;
+                continue;
+            }
+            if ch == '\\' && in_quotes {
+                escaped = true;
+                continue;
+            }
+            if ch == '"' {
+                in_quotes = !in_quotes;
+                continue;
+            }
+            if ch == target && !in_quotes {
+                return Some(index);
+            }
+        }
+
+        None
+    }
+
+    fn is_canonical_array_length(length: &str) -> bool {
+        !length.is_empty()
+            && length.chars().all(|ch| ch.is_ascii_digit())
+            && (length == "0" || !length.starts_with('0'))
     }
 
     fn parse_field_value(&mut self, depth: usize) -> ToonResult<Value> {
@@ -708,7 +885,40 @@ impl<'a> Parser<'a> {
             return Err(self.parse_error_with_context("Expected '[' at the start of root array"));
         }
 
+        if self.parse_canonical_empty_array()? {
+            if depth > 0 {
+                return Ok(Value::Array(Vec::new()));
+            }
+
+            self.skip_newlines()?;
+            if !matches!(self.current_token, Token::Eof) {
+                return Err(
+                    self.parse_error_with_context("Unexpected content after empty array literal")
+                );
+            }
+            return Ok(Value::Array(Vec::new()));
+        }
+
         self.parse_array(depth)
+    }
+
+    fn parse_canonical_empty_array(&mut self) -> ToonResult<bool> {
+        if !matches!(self.current_token, Token::LeftBracket) {
+            return Ok(false);
+        }
+
+        if !matches!(self.scanner.peek(), Some(']')) {
+            return Ok(false);
+        }
+
+        self.advance()?;
+        self.advance()?;
+        if !matches!(self.current_token, Token::Eof | Token::Newline) {
+            return Err(
+                self.parse_error_with_context("Unexpected content after empty array literal")
+            );
+        }
+        Ok(true)
     }
 
     fn parse_array_header(
@@ -722,6 +932,9 @@ impl<'a> Parser<'a> {
         // Parse array length (plain integer only)
         // Supports formats: [N], [N|], [N\t] (no # marker)
         let length = if let Token::SignedInteger(n) = &self.current_token {
+            if self.scanner.last_token_text().starts_with('-') {
+                return Err(self.parse_error_with_context(format!("Invalid array length: {n}")));
+            }
             *n as usize
         } else if let Token::UnsignedInteger(n) = &self.current_token {
             *n as usize
@@ -733,6 +946,12 @@ impl<'a> Parser<'a> {
                         "Length marker '#' is not supported. Use [N] format instead of [#N]",
                     )
                     .with_suggestion("Remove the '#' prefix from the array length"));
+            }
+
+            if s.len() > 1 && s.starts_with('0') {
+                return Err(self.parse_error_with_context(format!(
+                    "Invalid array length with leading zero: {s}"
+                )));
             }
 
             // Plain string that's a number: "3"
@@ -782,6 +1001,15 @@ impl<'a> Parser<'a> {
             )));
         }
         self.advance()?;
+
+        if self.options.strict
+            && self.scanner.last_whitespace_count() > 0
+            && matches!(self.current_token, Token::LeftBrace | Token::Colon)
+        {
+            return Err(self.parse_error_with_context(
+                "Whitespace is not allowed between array header segments in strict mode",
+            ));
+        }
 
         let fields = if matches!(self.current_token, Token::LeftBrace) {
             self.advance()?;
@@ -1199,6 +1427,12 @@ impl<'a> Parser<'a> {
                                         };
                                     self.layout_pop();
 
+                                    if self.options.strict && obj.contains_key(&field_key) {
+                                        return Err(self.parse_error_with_context(format!(
+                                            "Duplicate sibling key '{field_key}' is not allowed \
+                                             in strict mode"
+                                        )));
+                                    }
                                     obj.insert(field_key, field_value);
 
                                     if matches!(self.current_token, Token::Newline) {

--- a/src/decode/scanner.rs
+++ b/src/decode/scanner.rs
@@ -24,6 +24,17 @@ pub enum Token {
     Eof,
 }
 
+#[derive(Debug, Clone)]
+pub struct ScannerCheckpoint {
+    position: usize,
+    line: usize,
+    column: usize,
+    active_delimiter: Option<Delimiter>,
+    last_line_indent: usize,
+    last_whitespace_count: usize,
+    last_token_text: String,
+}
+
 /// Scanner that tokenizes TOON input into a sequence of tokens.
 #[derive(Debug)]
 pub struct Scanner {
@@ -108,6 +119,28 @@ impl Scanner {
 
     pub fn peek_ahead(&self, offset: usize) -> Option<char> {
         self.input.get(self.position + offset).copied()
+    }
+
+    pub fn checkpoint(&self) -> ScannerCheckpoint {
+        ScannerCheckpoint {
+            position: self.position,
+            line: self.line,
+            column: self.column,
+            active_delimiter: self.active_delimiter,
+            last_line_indent: self.last_line_indent,
+            last_whitespace_count: self.last_whitespace_count,
+            last_token_text: self.last_token_text.clone(),
+        }
+    }
+
+    pub fn restore(&mut self, checkpoint: ScannerCheckpoint) {
+        self.position = checkpoint.position;
+        self.line = checkpoint.line;
+        self.column = checkpoint.column;
+        self.active_delimiter = checkpoint.active_delimiter;
+        self.last_line_indent = checkpoint.last_line_indent;
+        self.last_whitespace_count = checkpoint.last_whitespace_count;
+        self.last_token_text = checkpoint.last_token_text;
     }
 
     pub fn advance(&mut self) -> Option<char> {
@@ -267,6 +300,33 @@ impl Scanner {
                     't' => value.push('\t'),
                     '"' => value.push('"'),
                     '\\' => value.push('\\'),
+                    'u' => {
+                        let mut hex = String::with_capacity(4);
+                        for _ in 0..4 {
+                            if let Some(hex_ch) = self.advance() {
+                                if hex_ch.is_ascii_hexdigit() {
+                                    hex.push(hex_ch);
+                                } else {
+                                    let (line, col) = self.current_position();
+                                    return Err(ToonError::parse_error(
+                                        line,
+                                        col,
+                                        "Invalid Unicode escape: expected four hexadecimal digits",
+                                    ));
+                                }
+                            } else {
+                                let (line, col) = self.current_position();
+                                return Err(ToonError::parse_error(
+                                    line,
+                                    col,
+                                    "Incomplete Unicode escape",
+                                ));
+                            }
+                        }
+
+                        let (line, col) = self.current_position();
+                        value.push(Self::parse_unicode_scalar(&hex, line, col)?);
+                    }
                     _ => {
                         let (line, col) = self.current_position();
                         return Err(ToonError::parse_error(
@@ -488,6 +548,27 @@ impl Scanner {
                         't' => value.push('\t'),
                         '"' => value.push('"'),
                         '\\' => value.push('\\'),
+                        'u' => {
+                            if i + 4 >= chars.len() {
+                                return Err(ToonError::parse_error(
+                                    self.line,
+                                    self.column,
+                                    "Incomplete Unicode escape",
+                                ));
+                            }
+
+                            let hex: String = chars[i + 1..i + 5].iter().collect();
+                            if !hex.chars().all(|c| c.is_ascii_hexdigit()) {
+                                return Err(ToonError::parse_error(
+                                    self.line,
+                                    self.column,
+                                    "Invalid Unicode escape: expected four hexadecimal digits",
+                                ));
+                            }
+
+                            value.push(Self::parse_unicode_scalar(&hex, self.line, self.column)?);
+                            i += 4;
+                        }
                         _ => {
                             return Err(ToonError::parse_error(
                                 self.line,
@@ -558,6 +639,16 @@ impl Scanner {
         }
 
         Ok(Token::String(trimmed.to_string(), false))
+    }
+
+    fn parse_unicode_scalar(hex: &str, line: usize, column: usize) -> ToonResult<char> {
+        let codepoint = u32::from_str_radix(hex, 16).map_err(|_| {
+            ToonError::parse_error(line, column, format!("Invalid Unicode escape: \\u{hex}"))
+        })?;
+
+        char::from_u32(codepoint).ok_or_else(|| {
+            ToonError::parse_error(line, column, format!("Invalid Unicode scalar: \\u{hex}"))
+        })
     }
 
     pub fn detect_delimiter(&mut self) -> Option<Delimiter> {

--- a/src/encode/mod.rs
+++ b/src/encode/mod.rs
@@ -322,7 +322,11 @@ fn write_array(
     validate_depth(depth, MAX_DEPTH)?;
 
     if arr.is_empty() {
-        writer.write_empty_array_with_key(key, depth)?;
+        if key.is_none() && depth == 0 {
+            writer.write_str("[]")?;
+        } else {
+            writer.write_empty_array_with_key(key, depth)?;
+        }
         return Ok(());
     }
 
@@ -352,6 +356,10 @@ fn is_tabular_array(arr: &[Value]) -> Option<Vec<String>> {
     }
 
     let first_obj = first.as_object()?;
+    if first_obj.is_empty() {
+        return None;
+    }
+
     let keys: Vec<String> = first_obj.keys().cloned().collect();
 
     // First object must have only primitive values
@@ -588,7 +596,9 @@ fn encode_nested_array(
                             // (rows for tabular, items for non-uniform)
                             writer.write_key(first_key)?;
 
-                            if let Some(keys) = is_tabular_array(arr) {
+                            if arr.is_empty() {
+                                writer.write_str(": []")?;
+                            } else if let Some(keys) = is_tabular_array(arr) {
                                 // Tabular array: write inline with correct indentation
                                 encode_list_item_tabular_array(writer, arr, &keys, depth + 1)?;
                             } else {
@@ -622,7 +632,11 @@ fn encode_nested_array(
                         match value {
                             Value::Array(arr) => {
                                 writer.write_key(key)?;
-                                write_array(writer, None, arr, depth + 2)?;
+                                if arr.is_empty() {
+                                    writer.write_str(": []")?;
+                                } else {
+                                    write_array(writer, None, arr, depth + 2)?;
+                                }
                             }
                             Value::Object(nested_obj) => {
                                 writer.write_key(key)?;
@@ -729,7 +743,7 @@ mod tests {
     fn test_encode_empty_array() {
         let obj = json!({"items": []});
         let result = encode_default(&obj).unwrap();
-        assert_eq!(result, "items[0]:");
+        assert_eq!(result, "items: []");
     }
 
     #[test]

--- a/src/encode/writer.rs
+++ b/src/encode/writer.rs
@@ -123,16 +123,11 @@ impl Writer {
                 self.write_indent(depth)?;
             }
             self.write_key(k)?;
+            self.write_str(": []")?;
+        } else {
+            self.write_str("[0]:")?;
         }
-        self.write_char('[')?;
-        self.write_str("0")?;
-
-        if self.options.delimiter != Delimiter::Comma {
-            self.write_delimiter()?;
-        }
-
-        self.write_char(']')?;
-        self.write_char(':')
+        Ok(())
     }
 
     pub fn needs_quoting(&self, s: &str, context: QuotingContext) -> bool {
@@ -327,6 +322,6 @@ mod tests {
         let mut writer = Writer::new(opts);
 
         writer.write_empty_array_with_key(Some("items"), 0).unwrap();
-        assert_eq!(writer.finish(), "items[0]:");
+        assert_eq!(writer.finish(), "items: []");
     }
 }

--- a/src/utils/string.rs
+++ b/src/utils/string.rs
@@ -14,6 +14,9 @@ pub fn escape_string(s: &str) -> String {
             '\t' => result.push_str("\\t"),
             '"' => result.push_str("\\\""),
             '\\' => result.push_str("\\\\"),
+            '\u{0000}'..='\u{001f}' => {
+                result.push_str(&format!("\\u{:04x}", ch as u32));
+            }
             _ => result.push(ch),
         }
     }
@@ -29,6 +32,7 @@ pub fn escape_string(s: &str) -> String {
 /// - `\n` → newline
 /// - `\r` → carriage return
 /// - `\t` → tab
+/// - `\uXXXX` → Unicode scalar value in the basic multilingual plane
 ///
 /// Any other escape sequence MUST cause an error.
 ///
@@ -72,10 +76,42 @@ pub fn unescape_string(s: &str) -> Result<String, String> {
                         chars.next();
                         position += 1;
                     }
+                    'u' => {
+                        chars.next();
+                        position += 1;
+
+                        let mut hex = String::with_capacity(4);
+                        for _ in 0..4 {
+                            if let Some(hex_ch) = chars.next() {
+                                position += 1;
+                                if hex_ch.is_ascii_hexdigit() {
+                                    hex.push(hex_ch);
+                                } else {
+                                    return Err(format!(
+                                        "Invalid Unicode escape at position {position}: expected \
+                                         four hexadecimal digits",
+                                    ));
+                                }
+                            } else {
+                                return Err(format!(
+                                    "Incomplete Unicode escape at position {position}: expected \
+                                     four hexadecimal digits",
+                                ));
+                            }
+                        }
+
+                        let codepoint = u32::from_str_radix(&hex, 16).map_err(|_| {
+                            format!("Invalid Unicode escape '\\u{hex}' at position {position}")
+                        })?;
+                        let scalar = char::from_u32(codepoint).ok_or_else(|| {
+                            format!("Invalid Unicode scalar '\\u{hex}' at position {position}")
+                        })?;
+                        result.push(scalar);
+                    }
                     _ => {
                         return Err(format!(
                             "Invalid escape sequence '\\{next}' at position {position}. Only \
-                             \\\\, \\\", \\n, \\r, \\t are valid",
+                             \\\\, \\\", \\n, \\r, \\t, \\uXXXX are valid",
                         ));
                     }
                 }
@@ -136,6 +172,10 @@ pub fn needs_quoting(s: &str, delimiter: char) -> bool {
     }
 
     if s.contains('\n') || s.contains('\r') || s.contains('\t') {
+        return true;
+    }
+
+    if s.chars().any(char::is_control) {
         return true;
     }
 
@@ -208,6 +248,10 @@ mod tests {
         assert_eq!(unescape_string("back\\\\slash").unwrap(), "back\\slash");
         assert_eq!(unescape_string("tab\\there").unwrap(), "tab\there");
         assert_eq!(unescape_string("return\\rhere").unwrap(), "return\rhere");
+        assert_eq!(
+            unescape_string("unicode\\u0004escape").unwrap(),
+            "unicode\u{4}escape"
+        );
     }
 
     #[test]

--- a/tests/errors.rs
+++ b/tests/errors.rs
@@ -6,6 +6,7 @@ use toon_format::{
     decode,
     decode_default,
     decode_strict,
+    encode_default,
     DecodeOptions,
     ToonError,
 };
@@ -111,6 +112,195 @@ fn test_length_mismatch_non_strict_mode() {
         let result = decode_default::<Value>(input);
         println!("Non-strict test for '{input}': {result:?}");
     }
+}
+
+#[test]
+fn test_non_strict_preserves_array_body_errors() {
+    let options = DecodeOptions::new().with_strict(false);
+    let result = decode::<Value>("items[2]: a", &options);
+
+    assert!(
+        result.is_err(),
+        "Non-strict malformed-header fallback must not hide array length mismatches"
+    );
+}
+
+#[test]
+fn test_canonical_empty_array_rejects_trailing_content() {
+    let object_result = decode_strict::<Value>("items: []junk");
+    assert!(
+        object_result.is_err(),
+        "Canonical empty array must be a complete value token"
+    );
+
+    let options = DecodeOptions::new().with_strict(false);
+    let root_result = decode::<Value>("[]junk", &options);
+    assert!(
+        root_result.is_err(),
+        "Non-strict root empty array must not silently discard trailing content"
+    );
+
+    let multiline_root_result = decode::<Value>("[]\nfoo: 1", &options);
+    assert!(
+        multiline_root_result.is_err(),
+        "Non-strict root empty array must not silently discard following lines"
+    );
+}
+
+#[test]
+fn test_canonical_empty_array_allows_sibling_fields() {
+    let decoded = decode_strict::<Value>("a: []\nb: 1").unwrap();
+    assert_eq!(decoded, json!({"a": [], "b": 1}));
+
+    let decoded = decode_strict::<Value>("outer:\n  a: []\n  b: 2").unwrap();
+    assert_eq!(decoded, json!({"outer": {"a": [], "b": 2}}));
+
+    let value = json!({"a": [], "b": 1});
+    let encoded = encode_default(&value).unwrap();
+    assert_eq!(encoded, "a: []\nb: 1");
+    let round_tripped: Value = decode_default(&encoded).unwrap();
+    assert_eq!(round_tripped, value);
+}
+
+#[test]
+fn test_unicode_escape_scanner_errors_include_position() {
+    let invalid_scalar = decode_strict::<Value>("value: \"\\uD800\"").unwrap_err();
+    match invalid_scalar {
+        ToonError::ParseError {
+            line,
+            column,
+            message,
+            ..
+        } => {
+            assert_eq!(line, 1);
+            assert!(column > 0);
+            assert!(message.contains("Invalid Unicode scalar"));
+        }
+        err => panic!("Expected located parse error for invalid scalar, got {err:?}"),
+    }
+
+    let incomplete_escape = decode_strict::<Value>("value: \"\\u12").unwrap_err();
+    match incomplete_escape {
+        ToonError::ParseError {
+            line,
+            column,
+            message,
+            ..
+        } => {
+            assert_eq!(line, 1);
+            assert!(column > 0);
+            assert!(message.contains("Incomplete Unicode escape"));
+        }
+        err => panic!("Expected located parse error for incomplete escape, got {err:?}"),
+    }
+}
+
+#[test]
+fn test_tabular_unicode_escape_errors_include_position() {
+    let invalid_scalar = decode_strict::<Value>("items[1]{name}:\n  \"\\uD800\"").unwrap_err();
+    match invalid_scalar {
+        ToonError::ParseError {
+            line,
+            column,
+            message,
+            ..
+        } => {
+            assert_eq!(line, 2);
+            assert!(column > 0);
+            assert!(message.contains("Invalid Unicode scalar"));
+        }
+        err => panic!("Expected located parse error for tabular invalid scalar, got {err:?}"),
+    }
+
+    let incomplete_escape = decode_strict::<Value>("items[1]{name}:\n  \"\\u12").unwrap_err();
+    match incomplete_escape {
+        ToonError::ParseError {
+            line,
+            column,
+            message,
+            ..
+        } => {
+            assert_eq!(line, 2);
+            assert!(column > 0);
+            assert!(
+                message.contains("Incomplete Unicode escape"),
+                "Expected incomplete Unicode escape message, got: {message}"
+            );
+        }
+        err => panic!("Expected located parse error for tabular incomplete escape, got {err:?}"),
+    }
+}
+
+#[test]
+fn test_strict_array_header_segment_whitespace_errors() {
+    let header_before_fields = decode_strict::<Value>("items[1] {name}:\n  Alice");
+    assert!(
+        header_before_fields.is_err(),
+        "Strict mode must reject whitespace between array header segments"
+    );
+
+    let header_before_colon = decode_strict::<Value>("items[1] : Alice");
+    assert!(
+        header_before_colon.is_err(),
+        "Strict mode must reject whitespace before array header colon"
+    );
+}
+
+#[test]
+fn test_strict_duplicate_sibling_key_errors() {
+    let object_duplicate = decode_strict::<Value>("a: 1\na: 2");
+    assert!(
+        object_duplicate.is_err(),
+        "Strict mode must reject duplicate object sibling keys"
+    );
+
+    let nested_duplicate = decode_strict::<Value>("items[1]:\n  - a: 1\n    a: 2");
+    assert!(
+        nested_duplicate.is_err(),
+        "Strict mode must reject duplicate sibling keys inside list-item objects"
+    );
+}
+
+#[test]
+fn test_non_strict_malformed_headers_fall_back_only_with_same_line_colon() {
+    let options = DecodeOptions::new().with_strict(false);
+
+    let decoded: Value = decode("foo[1][bar]: 10", &options).unwrap();
+    assert_eq!(decoded, json!({"foo[1][bar]": 10}));
+
+    let result = decode::<Value>("foo[1][bar]\nnext: 2", &options);
+    assert!(
+        result.is_err(),
+        "Malformed-header fallback must not consume later lines"
+    );
+}
+
+#[test]
+fn test_non_strict_valid_quoted_field_headers_do_not_fall_back() {
+    let options = DecodeOptions::new().with_strict(false);
+
+    let decoded: Value = decode("items[1]{\"a:b\"}:\n  x", &options).unwrap();
+    assert_eq!(decoded, json!({"items": [{"a:b": "x"}]}));
+
+    let decoded: Value = decode("items[1]{\"a]b\"}:\n  x", &options).unwrap();
+    assert_eq!(decoded, json!({"items": [{"a]b": "x"}]}));
+
+    let decoded: Value = decode("items[1]{\"a}b\"}:\n  x", &options).unwrap();
+    assert_eq!(decoded, json!({"items": [{"a}b": "x"}]}));
+}
+
+#[test]
+fn test_non_canonical_lengths_are_not_array_headers() {
+    let options = DecodeOptions::new().with_strict(false);
+
+    let leading_zero: Value = decode("items[03]: a,b,c", &options).unwrap();
+    assert_eq!(leading_zero, json!({"items[03]": "a,b,c"}));
+
+    let negative: Value = decode("items[-1]: a,b,c", &options).unwrap();
+    assert_eq!(negative, json!({"items[-1]": "a,b,c"}));
+
+    assert!(decode_strict::<Value>("items[03]: a,b,c").is_err());
+    assert!(decode_strict::<Value>("items[-1]: a,b,c").is_err());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Update the checked-in spec submodule reference and README wording for TOON v3.3.
- Align empty-array encoding and decoding with the canonical `key: []` and root `[]` forms while preserving legacy `[0]` support where needed.
- Tighten decoder handling for non-canonical array headers, malformed-header fallback, strict duplicate sibling keys, quoted tabular field names, and Unicode escape diagnostics.

## Why

The decoder accepted or silently discarded several inputs that TOON v3.3 treats as invalid or non-canonical.
Some of those cases could lose trailing content after `[]`, reinterpret `[03]` or `[-1]` as array headers, or turn valid quoted field names into literal malformed keys in non-strict mode.
The scanner fallback also cloned the full input buffer before array parsing, which made array-heavy inputs do unnecessary memory work.

## Notes

- Non-strict malformed-header fallback is now limited to header syntax cases and uses a lightweight scanner checkpoint instead of cloning the full scanner input.
- Root `[]` still rejects trailing content, while nested `key: []` can be followed by sibling fields and round-trips from the encoder.
- Unicode escape scanner errors now include line and column information for invalid scalar and incomplete escape cases.

## Validation

- `cargo +nightly fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build --verbose`
- `cargo build --examples --verbose`
- `cargo test --verbose --all-targets`
- `cargo test --all-features`
- `git diff --check`
